### PR TITLE
Buffer payment, apprise notifications

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8
+FROM python:3.11-alpine
 WORKDIR /app
 RUN apt-get update && apt-get install -y git
 RUN git clone https://github.com/HamletDuFromage/paybybot3 .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM python:3.11-alpine
 WORKDIR /app
-RUN apt-get update && apt-get install -y git
+RUN apk update
+RUN apk add git
 RUN git clone https://github.com/HamletDuFromage/paybybot3 .
 RUN pip install .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.8
+WORKDIR /app
+RUN apt-get update && apt-get install -y git
+RUN git clone https://github.com/HamletDuFromage/paybybot3 .
+RUN pip install .

--- a/README.md
+++ b/README.md
@@ -99,16 +99,15 @@ example_account:
   paybyphone:
     login: "+330612345678"
     password: password
-  email:
-    login: your-email@gmail.com
-    password: password
+  apprise: #optional
+    host: "http://localhost:8000/notify/KEY"
+    tags: 
+      - "my_tag"
+    notify: true
+    notify_on_error: true
   paymentAccountId: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
-  notify:
-    - your-email@gmail.com
-  notify_on_error:
-    - your-email@gmail.com
 ```
 
-For the moment we only support Gmail to send you notifications. You will need an [App Password](https://support.google.com/mail/answer/185833).
+Notifications are delivered through the [Apprise API](https://github.com/caronc/apprise-api) 
 
 The `paymentAccountId` can be found in the output of the `payment-accounts` command.

--- a/paybybot3/__init__.py
+++ b/paybybot3/__init__.py
@@ -16,10 +16,12 @@ LOGGER_CONFIG = {
             'stream': 'ext://sys.stdout'
         },
         'file': {
-            'class': 'logging.FileHandler',
+            'class': 'logging.handlers.RotatingFileHandler',
             'formatter': 'standard',
             'filename': expanduser('~/paybybot3.log'),
-            'mode': 'a'
+            'mode': 'a',
+            'maxBytes': 100_000,
+            'backupCount': 2
         }
     },
     'root': {

--- a/paybybot3/__init__.py
+++ b/paybybot3/__init__.py
@@ -1,9 +1,31 @@
-import logging
+import logging.config
 from os.path import expanduser
 
 
-logging.basicConfig(
-    format="%(asctime)s %(message)s",
-    filename=expanduser("~/paybybot3.log"),
-    level=logging.INFO,
-)
+LOGGER_CONFIG = {
+    'version': 1,
+    'formatters': {
+        'standard': {
+            'format': '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+        }
+    },
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+            'formatter': 'standard',
+            'stream': 'ext://sys.stdout'
+        },
+        'file': {
+            'class': 'logging.FileHandler',
+            'formatter': 'standard',
+            'filename': expanduser('~/paybybot3.log'),
+            'mode': 'a'
+        }
+    },
+    'root': {
+        'level': 'INFO',
+        'handlers': ['console', 'file']
+    }
+}
+
+logging.config.dictConfig(LOGGER_CONFIG)

--- a/paybybot3/__main__.py
+++ b/paybybot3/__main__.py
@@ -157,6 +157,7 @@ def pay(config_name, location, rate, duration, buffer, config):
             if buffer:
                 expireTime = min([session["expireTime"] for session in sessions])
                 remainingTime = expireTime - datetime.utcnow()
+                logging.info(f"Waiting for the current session to expire in: {remainingTime}")
                 sleep(remainingTime.total_seconds() + 15)
             else:
                 return

--- a/paybybot3/__main__.py
+++ b/paybybot3/__main__.py
@@ -159,8 +159,8 @@ def pay(config_name, location, rate, duration, buffer, config):
                 remainingTime = expireTime - datetime.utcnow()
                 logging.info(f"Waiting for the current session to expire in: {remainingTime}")
                 sleep(max(0, remainingTime.total_seconds() + 15))
-            else:
-                return
+                _pay(config, location, duration)
+            return
         bot.pay(
             durationQuantity=duration,
             durationTimeUnit="Days",

--- a/paybybot3/__main__.py
+++ b/paybybot3/__main__.py
@@ -158,7 +158,7 @@ def pay(config_name, location, rate, duration, buffer, config):
                 expireTime = min([session["expireTime"] for session in sessions])
                 remainingTime = expireTime - datetime.utcnow()
                 logging.info(f"Waiting for the current session to expire in: {remainingTime}")
-                sleep(max(0, remainingTime.total_seconds() + 15))
+                sleep(max(0, remainingTime.total_seconds() + 1))
                 _pay(config, location, duration)
             return
         bot.pay(

--- a/paybybot3/__main__.py
+++ b/paybybot3/__main__.py
@@ -2,6 +2,7 @@ import functools
 from pprint import pprint
 import sys
 from time import sleep
+from datetime import datetime
 
 import click
 
@@ -131,7 +132,8 @@ def alert(config_name, location, config):
 @click.option("--rate", required=True, type=int)
 @click.option("--duration", required=True, type=str)
 @click.option("--config", required=False, type=str)
-def pay(config_name, location, rate, duration, config):
+@click.option("--buffer", is_flag=True)
+def pay(config_name, location, rate, duration, buffer, config):
     """
     1. Check if there is an ongoing subscription
 
@@ -152,7 +154,12 @@ def pay(config_name, location, rate, duration, config):
         if sessions:
             print("Already registered", file=sys.stderr)
             pprint(sessions)
-            return
+            if buffer:
+                expireTime = min([session["expireTime"] for session in sessions])
+                remainingTime = expireTime - datetime.utcnow()
+                sleep(remainingTime.total_seconds() + 15)
+            else:
+                return
         bot.pay(
             durationQuantity=duration,
             durationTimeUnit="Days",

--- a/paybybot3/__main__.py
+++ b/paybybot3/__main__.py
@@ -158,7 +158,7 @@ def pay(config_name, location, rate, duration, buffer, config):
                 expireTime = min([session["expireTime"] for session in sessions])
                 remainingTime = expireTime - datetime.utcnow()
                 logging.info(f"Waiting for the current session to expire in: {remainingTime}")
-                sleep(remainingTime.total_seconds() + 15)
+                sleep(max(0, remainingTime.total_seconds() + 15))
             else:
                 return
         bot.pay(

--- a/paybybot3/notifs.py
+++ b/paybybot3/notifs.py
@@ -1,5 +1,6 @@
 from smtplib import SMTP
 import logging
+import requests
 
 
 EMAIL_TEMPLATE = """\
@@ -11,7 +12,7 @@ Subject: {subject}
 """
 
 
-def notify(email, pwd, subject, message, to=None):
+def notify_email(email, pwd, subject, message, to=None):
     # TODO: add server as parameter
     if to is None:
         to = [email]
@@ -23,3 +24,12 @@ def notify(email, pwd, subject, message, to=None):
         ).encode("utf8")
         server.sendmail(email, to, email_text)
         logging.info("sent email to %s with message: %s", email, message)
+
+def notify_apprise(host, title, body, tags):
+    payload = {
+        "tag": " ".join(tags),
+        "title": title,
+        "body": body
+    }
+    response = requests.post(url=host, json=payload, headers={"Content-Type": "application/json"})
+    logging.info("sent notification to %s with message: %s", tags, body)


### PR DESCRIPTION
I've forked your repo for own use case, and I figured you might want to cherry-pick some commits, or all of them, upstream. 

The important one is adding the --buffer flag for payments, which waits until the current session expires before it triggers the payment routine. I've also removed the gmail notifications and replaced them with apprise (self-hosted service that support a ton of messaging software). I use tags with apprise, but the code could be effortlessly changed to support urls.

Lastly I've written a basic Dockerfile that'll need to edited to point to your repo, should you decide to keep it