### PR TITLE
Add --unit argument to pay() through CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .vscode/
 __pycache__/
+venv/
 *.egg-info/
 build/
 dist/

--- a/README.md
+++ b/README.md
@@ -56,13 +56,13 @@ Usage: paybybot3 pay [OPTIONS] CONFIG_NAME
   4. Notify on failure
 
 Options:
---location TEXT        [required]
---rate INTEGER         [required]
---duration TEXT        [required]
---unit [Days|Minutes]  Default: Days
---buffer
---config TEXT
---help                 Show this message and exit.
+  --location TEXT              [required]
+  --rate INTEGER               [required]
+  --duration TEXT              [required]
+  --unit [Days|Hours|Minutes]  Default: Days
+  --buffer
+  --config TEXT
+  --help                       Show this message and exit.
 ```
 
 ### vehicles

--- a/README.md
+++ b/README.md
@@ -56,12 +56,13 @@ Usage: paybybot3 pay [OPTIONS] CONFIG_NAME
   4. Notify on failure
 
 Options:
-  --location TEXT  [required]
-  --rate INTEGER   [required]
-  --duration TEXT  [required]
-  --buffer BOOLEAN
-  --config TEXT
-  --help           Show this message and exit.
+--location TEXT        [required]
+--rate INTEGER         [required]
+--duration TEXT        [required]
+--unit [Days|Minutes]  Default: Days
+--buffer
+--config TEXT
+--help                 Show this message and exit.
 ```
 
 ### vehicles

--- a/paybybot3/__main__.py
+++ b/paybybot3/__main__.py
@@ -130,7 +130,7 @@ def alert(config_name, location, config):
 @click.option("--location", required=True, type=str)
 @click.option("--rate", required=True, type=int)
 @click.option("--duration", required=True, type=str)
-@click.option("--unit", default="Days", type=click.Choice(["Days", "Minutes"]), help="Default: Days")
+@click.option("--unit", default="Days", type=click.Choice(["Days", "Hours", "Minutes"]), help="Default: Days")
 @click.option("--buffer", is_flag=True)
 @click.option("--config", required=False, type=str)
 def pay(config_name, location, rate, duration, unit, buffer, config):


### PR DESCRIPTION
- Add `--unit` (time unit) argument to pay through CLI
- Replace deprecated `utcnow` method
- Add `venv/` to `.gitignore`
- Update `README.md` to reflect the changes